### PR TITLE
Username and password format is wrong in mongodb url

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -32,7 +32,7 @@ explicitly::
 
 Monary can also accept MongoDB URI strings::
 
-    >>> client = Monary("mongodb://me@password:test.example.net:2500/database?replicaSet=test&connectTimeoutMS=300000")
+    >>> client = Monary("mongodb://me:password@test.example.net:2500/database?replicaSet=test&connectTimeoutMS=300000")
 
 .. seealso::
 


### PR DESCRIPTION
Refer to https://docs.mongodb.com/manual/reference/connection-string/
Correct mongodb url format is: 
```
mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
```